### PR TITLE
trading days specification improvement

### DIFF
--- a/R/calendars.R
+++ b/R/calendars.R
@@ -728,7 +728,7 @@ print.JD3_FIXEDWEEKDAY<-function(x, ...){
 #'
 #' @examples
 print.JD3_EASTERDAY<-function(x, ...){
-  cat('Easter related day: offset=', xoffset, sep='')
+  cat('Easter related day: offset=', x$offset, sep='')
   if (x$weight != 1)cat(' , weight=', x$weight, sep='')
 
 }

--- a/R/modellingcontext.R
+++ b/R/modellingcontext.R
@@ -105,6 +105,7 @@ modelling_context<-function(calendars=NULL, variables=NULL){
 #' @rdname jd3_utilities
 .p2r_modellingcontext<-function(p){
   n<-length(p$calendars)
+  lcal <- lvar <- NULL
   if (n > 0){
     lcal<-lapply(1:n, function(i){return(.p2r_calendardef(p$calendars[[i]]$value))})
     ns<-sapply(1:n, function(i){return(p$calendars[[i]]$key)})

--- a/R/regarima_generic.R
+++ b/R/regarima_generic.R
@@ -15,6 +15,64 @@ coef.JD3_REGARIMA_RSLTS <- function(object, component = c("regression", "arima",
       regarima_coef_table(object)[,1])
   }
 }
+sarima_coef_table <- function(x, cov = NULL, ndf = NULL,...){
+  m <- x
+  if (! is.null(m$phi)) p<-dim(m$phi)[2]else p<-0
+  if (! is.null(m$theta)) q<-dim(m$theta)[2]else q<-0
+  if (! is.null(m$bphi)) bp<-dim(m$bphi)[2]else bp<-0
+  if (! is.null(m$btheta)) bq<-dim(m$btheta)[2]else bq<-0
+  sarima_orders = list(p = p, d = m$d, q = q, bp = bp, bd = m$bd, bq = bq)
+  names<-NULL
+  if (p > 0){names=c(names,paste0("phi(", 1:p, ')')) }
+  if (q > 0){names=c(names,paste0("theta(", 1:q, ')')) }
+  if (bp > 0){names=c(names,paste0("bphi(", 1:bp, ')')) }
+  if (bq > 0){names=c(names,paste0("btheta(", 1:bq,')')) }
+  if (! is.null(names)){
+    all<-t(cbind(m$phi, m$theta, m$bphi, m$btheta))
+    fr<-as.data.frame(all, row.names = names)
+    for(i in colnames(fr)){
+      fr[,i] <- unlist(fr[,i])
+    }
+    if(!is.null(cov) & !is.null(ndf)){
+      fr$pvalue <- fr$t <- fr$stde <- NA
+      stde<-sqrt(diag(cov))
+      sel<-fr$type=='ESTIMATED'
+      t<-fr$value[sel]/stde
+      pval<-2*pt(abs(t), ndf, lower.tail = F)
+      fr$stde[sel]<-stde
+      fr$t[sel]<-t
+      fr$pvalue[sel]<-pval
+      colnames(fr) <- c("Estimate", "Type", "Std. Error",
+                        "T-stat", "Pr(>|t|)")
+    }else{
+      colnames(fr) <- c("Estimate", "Type")
+    }
+  }else{
+    fr <- NULL
+  }
+  list(sarima_orders = sarima_orders,
+       coef_table = fr)
+}
+regarima_coef_table <- function(x,...){
+  q <- x
+  if (length(q$description$variables)>0){
+    regs<-do.call("rbind", lapply(q$description$variables, function(z){z$coeff}))
+    xregs<-cbind(regs, stde=NA, t=NA, pvalue=NA)
+    stde<-sqrt(diag(q$estimation$bvar))
+    sel<-xregs$type=='ESTIMATED'
+    t<-xregs$value[sel]/stde
+    ndf<-q$estimation$likelihood$neffectiveobs-q$estimation$likelihood$nparams+1
+    pval<-2*pt(abs(t), ndf, lower.tail = F)
+    xregs$stde[sel]<-stde
+    xregs$t[sel]<-t
+    xregs$pvalue[sel]<-pval
+    colnames(xregs) <- c("Estimate", "Type", "Std. Error",
+                         "T-stat", "Pr(>|t|)")
+    xregs
+  }else{
+    NULL
+  }
+}
 
 # Method "JD3_REGARIMA_RSLTS" for the function logLik
 #' @export

--- a/R/regarima_spec.R
+++ b/R/regarima_spec.R
@@ -701,6 +701,9 @@ set_arima.default <- function(x,
 #' @param option to specify the set of trading days regression variables:
 #' \code{"TradingDays"} = six day-of-the-week regression variables;
 #' \code{"WorkingDays"} = one working/non-working day contrast variable;
+#' \code{"TD3"} = weeks, Saturdays, Sundays;
+#' \code{"TD3c"} = weeks, Fridays+Saturdays, Sundays;
+#' \code{"TD4"} = weeks, Fridays, Saturdays, Sundays;
 #' \code{"None"} = no correction for trading days and working days effects;
 #' \code{"UserDefined"} = userdefined trading days regressors.
 #' @param uservariable a vector of characters to specify the name of user-defined calendar regressors.
@@ -742,7 +745,7 @@ set_arima.default <- function(x,
 #' @param coef.type,leapyear.coef.type vector defining if the coefficients are fixed or estimated.
 #' @export
 set_tradingdays<- function(x,
-                           option = c(NA, "TradingDays", "WorkingDays", "None", "UserDefined"),
+                           option = c(NA, "TradingDays", "WorkingDays", "TD3", "TD3c", "TD4",, "None", "UserDefined"),
                            uservariable = NA,
                            stocktd = NA,
                            test = c(NA, "None", "Remove", "Add", "Separate_T", "Joint_F"),
@@ -761,7 +764,7 @@ set_tradingdays<- function(x,
 
 #' @export
 set_tradingdays.default <- function(x,
-                                    option = c(NA, "TradingDays", "WorkingDays", "None", "UserDefined"),
+                                    option = c(NA, "TradingDays", "WorkingDays", "TD3", "TD3c", "TD4", "None", "UserDefined"),
                                     uservariable = NA,
                                     stocktd = NA,
                                     test = c(NA, "None", "Remove", "Add", "Separate_T", "Joint_F"),
@@ -781,12 +784,14 @@ set_tradingdays.default <- function(x,
 
   if(!missing(option) & !any(is.na(option))){
     option <- match.arg(toupper(option)[1],
-                        choices = c("TRADINGDAYS", "WORKINGDAYS", "NONE","USERDEFINED"))
+                        choices = c("TRADINGDAYS", "WORKINGDAYS", "NONE","USERDEFINED",
+                                    "TD3", "TD3C", "TD4"))
     td$td <- switch(option,
                     WORKINGDAYS = "TD2",
                     TRADINGDAYS = "TD7",
                     USERDEFINED = "TD_NONE",
-                    NONE = "TD_NONE")
+                    NONE = "TD_NONE",
+                    option)
     td$users <- character()
   }
   if(!is.null(uservariable) &&
@@ -867,6 +872,9 @@ set_tradingdays.default <- function(x,
     }
     ntd <- switch(td$td,
                   TD2 = 1,
+                  TD3 = 2,
+                  TD3C = 3,
+                  TD4 = 3,
                   TD7 = 6,
                   length(td$users))
     if (length(coef) == 1){

--- a/man/set_easter.Rd
+++ b/man/set_easter.Rd
@@ -10,6 +10,8 @@ set_easter(
   julian = NA,
   duration = NA,
   test = c(NA, "Add", "Remove", "None"),
+  coef = NA,
+  coef.type = c(NA, "Estimated", "Fixed"),
   type = c(NA, "Unused", "Standard", "IncludeEaster", "IncludeEasterMonday")
 )
 }
@@ -29,6 +31,12 @@ to the RegARIMA model after the test;
 \code{"Remove"} = the Easter effect variable belongs to the initial regression model but can be removed
 from the RegARIMA model after the test;
 \code{"None"} = the Easter effect variable is not pre-tested and is included in the model.}
+
+\item{coef}{to set the coefficient of the easter regressor.}
+
+\item{coef.type}{a character defining the easter regressor coefficient estimation procedure.
+Possible procedures are: \code{"Estimated"} = coefficient is estimated,
+\code{"Fixed"} = the coefficients is fixed.}
 
 \item{type}{(TRAMO specific) a \code{character} that specifies the presence and the length of the Easter effect:
 \code{"Unused"} = the Easter effect is not considered; \code{"Standard"} = influences the period of \code{n} days strictly before Easter Sunday;

--- a/man/set_tradingdays.Rd
+++ b/man/set_tradingdays.Rd
@@ -12,10 +12,12 @@ set_tradingdays(
   test = c(NA, "None", "Remove", "Add", "Separate_T", "Joint_F"),
   autoadjust = NA,
   coef = NA,
+  coef.type = c(NA, "Undefined", "Fixed", "Initial"),
   automatic = c(NA, "Unused", "FTest", "WaldTest"),
   pftd = NA,
   leapyear = c(NA, "LeapYear", "LengthOfPeriod", "None"),
-  leapyear.coef = NA
+  leapyear.coef = NA,
+  leapyear.coef.type = c(NA, "Undefined", "Fixed", "Initial")
 )
 }
 \arguments{

--- a/man/set_tradingdays.Rd
+++ b/man/set_tradingdays.Rd
@@ -6,7 +6,8 @@
 \usage{
 set_tradingdays(
   x,
-  option = c(NA, "TradingDays", "WorkingDays", "None", "UserDefined"),
+  option = c(NA, "TradingDays", "WorkingDays", "TD3", "TD3c", "TD4", , "None",
+    "UserDefined"),
   uservariable = NA,
   stocktd = NA,
   test = c(NA, "None", "Remove", "Add", "Separate_T", "Joint_F"),
@@ -26,6 +27,9 @@ set_tradingdays(
 \item{option}{to specify the set of trading days regression variables:
 \code{"TradingDays"} = six day-of-the-week regression variables;
 \code{"WorkingDays"} = one working/non-working day contrast variable;
+\code{"TD3"} = weeks, Saturdays, Sundays;
+\code{"TD3c"} = weeks, Fridays+Saturdays, Sundays;
+\code{"TD4"} = weeks, Fridays, Saturdays, Sundays;
 \code{"None"} = no correction for trading days and working days effects;
 \code{"UserDefined"} = userdefined trading days regressors.}
 

--- a/man/set_tradingdays.Rd
+++ b/man/set_tradingdays.Rd
@@ -6,18 +6,18 @@
 \usage{
 set_tradingdays(
   x,
-  option = c(NA, "TradingDays", "WorkingDays", "None"),
+  option = c(NA, "TradingDays", "WorkingDays", "None", "UserDefined"),
   uservariable = NA,
   stocktd = NA,
   test = c(NA, "None", "Remove", "Add", "Separate_T", "Joint_F"),
   autoadjust = NA,
   coef = NA,
-  coef.type = c(NA, "Undefined", "Fixed", "Initial"),
+  coef.type = c(NA, "Fixed", "Estimated"),
   automatic = c(NA, "Unused", "FTest", "WaldTest"),
   pftd = NA,
   leapyear = c(NA, "LeapYear", "LengthOfPeriod", "None"),
   leapyear.coef = NA,
-  leapyear.coef.type = c(NA, "Undefined", "Fixed", "Initial")
+  leapyear.coef.type = c(NA, "Fixed", "Estimated")
 )
 }
 \arguments{
@@ -26,9 +26,11 @@ set_tradingdays(
 \item{option}{to specify the set of trading days regression variables:
 \code{"TradingDays"} = six day-of-the-week regression variables;
 \code{"WorkingDays"} = one working/non-working day contrast variable;
-\code{"None"} = no correction for trading days and working days effects.}
+\code{"None"} = no correction for trading days and working days effects;
+\code{"UserDefined"} = userdefined trading days regressors.}
 
-\item{uservariable}{a vector of characters to specify the name of user-defined calendar regressors.}
+\item{uservariable}{a vector of characters to specify the name of user-defined calendar regressors.
+When specified, automatically set \code{option = "UserDefined"}.}
 
 \item{stocktd}{a numeric indicating the day of the month when inventories and other stock are reported
 (to denote the last day of the month, set the variable to 31).
@@ -54,6 +56,8 @@ if at least one t-statistic is greater than 2.6 or if two t-statistics are great
 It is available when the transformation function is set to Auto.}
 
 \item{coef}{vector of coefficients for the tranding-days regressors.}
+
+\item{coef.type, leapyear.coef.type}{vector defining if the coefficients are fixed or estimated.}
 
 \item{automatic}{(TRAMO SPECIFIC) defines whether the calendar effects should be added to the model manually (\code{"Unused"}) or automatically.
 During the automatic selection, the choice of the number of calendar variables can be based on the F-Test (\code{"FTest"}) or the Wald Test (\code{"WaldTest"});


### PR DESCRIPTION
Improvement in specification of tradingdays :
- `coef` parameters for tradingdays/leapyear/easter (`set_tradingdays()` and `set_easter()`)
- userdefined trading days are now available
- some typos fixed